### PR TITLE
Config Parser Unit Tests and Bugfixes

### DIFF
--- a/config_parser.cc
+++ b/config_parser.cc
@@ -129,7 +129,7 @@ NginxConfigParser::TokenType NginxConfigParser::ParseToken(std::istream* input,
         continue;
       case TOKEN_STATE_TOKEN_TYPE_NORMAL:
         if (c == ' ' || c == '\t' || c == '\n' || c == '\t' ||
-            c == ';' || c == '{' || c == '}') {
+            c == ';' || c == '{' || c == '}' || c == '"' || c == '\'') {
           input->unget();
           return TOKEN_TYPE_NORMAL;
         }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -88,3 +88,22 @@ TEST_F(NginxConfigParserStringTest, OneLineTwoStatements) {
   EXPECT_EQ(config_.statements_[1]->tokens_[0], "baz");
   EXPECT_EQ(config_.statements_[1]->tokens_[1], "bop");
 }
+
+TEST_F(NginxConfigParserStringTest, ChildStatement) {
+  bool success = parseString("foo {\n\tbar baz;\n}");
+
+  EXPECT_TRUE(success);
+
+  // one statement
+  ASSERT_EQ(config_.statements_.size(), 1);
+  // one token
+  ASSERT_EQ(config_.statements_[0]->tokens_.size(), 1);
+  // child block has one statement
+  ASSERT_EQ(config_.statements_[0]->child_block_->statements_.size(), 1);
+  // child block statement has two tokens
+  ASSERT_EQ(config_.statements_[0]->child_block_->statements_[0]->tokens_.size(), 2);
+
+  EXPECT_EQ(config_.statements_[0]->tokens_[0], "foo");
+  EXPECT_EQ(config_.statements_[0]->child_block_->statements_[0]->tokens_[0], "bar");
+  EXPECT_EQ(config_.statements_[0]->child_block_->statements_[0]->tokens_[1], "baz");
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -29,3 +29,22 @@ TEST(NginxConfigParserTest, StatementParsed) {
   EXPECT_EQ(config.statements_[0]->tokens_[0], "port");
   EXPECT_EQ(config.statements_[0]->tokens_[1], "8080");
 }
+
+TEST(NginxConfigParserTest, InsignificantWhitespace) {
+  NginxConfigParser parser;
+  NginxConfig config;
+
+  std::stringstream test_config_stream(" \t   foo  \t   bar     ;    \t");
+
+  bool success = parser.Parse(&test_config_stream, &config);
+
+  EXPECT_TRUE(success);
+
+  // one statement
+  ASSERT_EQ(config.statements_.size(), 1);
+  // two tokens
+  ASSERT_EQ(config.statements_[0]->tokens_.size(), 2);
+
+  EXPECT_EQ(config.statements_[0]->tokens_[0], "foo");
+  EXPECT_EQ(config.statements_[0]->tokens_[1], "bar");
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -24,9 +24,7 @@ class NginxConfigParserStringTest : public ::testing::Test {
 };
 
 TEST_F(NginxConfigParserStringTest, StatementParsed) {
-  bool success = parseString("port 8080;");
-
-  EXPECT_TRUE(success);
+  EXPECT_TRUE(parseString("port 8080;"));
 
   // one statement
   ASSERT_EQ(config_.statements_.size(), 1);
@@ -38,9 +36,7 @@ TEST_F(NginxConfigParserStringTest, StatementParsed) {
 }
 
 TEST_F(NginxConfigParserStringTest, InsignificantWhitespace) {
-  bool success = parseString(" \t   foo  \t   bar     ;    \t");
-
-  EXPECT_TRUE(success);
+  EXPECT_TRUE(parseString(" \t   foo  \t   bar     ;    \t"));
 
   // one statement
   ASSERT_EQ(config_.statements_.size(), 1);
@@ -52,15 +48,11 @@ TEST_F(NginxConfigParserStringTest, InsignificantWhitespace) {
 }
 
 TEST_F(NginxConfigParserStringTest, NoSemicolon) {
-  bool success = parseString("foo bar");
-
-  EXPECT_FALSE(success);
+  EXPECT_FALSE(parseString("foo bar"));
 }
 
 TEST_F(NginxConfigParserStringTest, UnexpectedNewline) {
-  bool success = parseString("\nfoo bar;");
-
-  EXPECT_TRUE(success);
+  EXPECT_TRUE(parseString("\nfoo bar;"));
 
   // one statement
   ASSERT_EQ(config_.statements_.size(), 1);
@@ -72,9 +64,7 @@ TEST_F(NginxConfigParserStringTest, UnexpectedNewline) {
 }
 
 TEST_F(NginxConfigParserStringTest, OneLineTwoStatements) {
-  bool success = parseString("foo bar; baz bop;");
-
-  EXPECT_TRUE(success);
+  EXPECT_TRUE(parseString("foo bar; baz bop;"));
 
   // two statements
   ASSERT_EQ(config_.statements_.size(), 2);
@@ -90,9 +80,7 @@ TEST_F(NginxConfigParserStringTest, OneLineTwoStatements) {
 }
 
 TEST_F(NginxConfigParserStringTest, ChildStatement) {
-  bool success = parseString("foo {\n\tbar baz;\n}");
-
-  EXPECT_TRUE(success);
+  EXPECT_TRUE(parseString("foo {\n\tbar baz;\n}"));
 
   // one statement
   ASSERT_EQ(config_.statements_.size(), 1);
@@ -109,15 +97,13 @@ TEST_F(NginxConfigParserStringTest, ChildStatement) {
 }
 
 TEST_F(NginxConfigParserStringTest, NestedChildStatement) {
-  bool success = parseString(
+  EXPECT_TRUE(parseString(
           "foo {\
             bar {\
               hello;\
             }\
             baz;\
-          }");
-
-  EXPECT_TRUE(success);
+          }"));
 
   NginxConfigStatement* fooStatement = &*config_.statements_[0];
 
@@ -134,21 +120,15 @@ TEST_F(NginxConfigParserStringTest, NestedChildStatement) {
 }
 
 TEST_F(NginxConfigParserStringTest, InvalidChildStatement_NoOpenBrace) {
-  bool success = parseString("foo } bar;");
-
-  EXPECT_FALSE(success);
+  EXPECT_FALSE(parseString("foo } bar;"));
 }
 
 TEST_F(NginxConfigParserStringTest, InvalidChildStatement_NoCloseBrace) {
-  bool success = parseString("foo { bar;");
-
-  EXPECT_FALSE(success);
+  EXPECT_FALSE(parseString("foo { bar;"));
 }
 
 TEST_F(NginxConfigParserStringTest, ExtraNewline) {
-  bool success = parseString("foo;\n\n\nbar;");
-
-  EXPECT_TRUE(success);
+  EXPECT_TRUE(parseString("foo;\n\n\nbar;"));
 
   // two statements
   ASSERT_EQ(config_.statements_.size(), 2);
@@ -162,9 +142,7 @@ TEST_F(NginxConfigParserStringTest, ExtraNewline) {
 }
 
 TEST_F(NginxConfigParserStringTest, Comments) {
-  bool success = parseString("foo; # this is a comment ;; } {\nbar;");
-
-  EXPECT_TRUE(success);
+  EXPECT_TRUE(parseString("foo; # this is a comment ;; } {\nbar;"));
 
   // two statements
   ASSERT_EQ(config_.statements_.size(), 2);
@@ -178,9 +156,7 @@ TEST_F(NginxConfigParserStringTest, Comments) {
 }
 
 TEST_F(NginxConfigParserStringTest, DoubleQuotes) {
-  bool success = parseString("foo = \"Hello, World!\";");
-
-  EXPECT_TRUE(success);
+  EXPECT_TRUE(parseString("foo = \"Hello, World!\";"));
 
   // one statement
   ASSERT_EQ(config_.statements_.size(), 1);
@@ -194,9 +170,7 @@ TEST_F(NginxConfigParserStringTest, DoubleQuotes) {
 }
 
 TEST_F(NginxConfigParserStringTest, DoubleQuotesSpecialChars) {
-  bool success = parseString("foo = \"test \n test; ' } {\";");
-
-  EXPECT_TRUE(success);
+  EXPECT_TRUE(parseString("foo = \"test \n test; ' } {\";"));
 
   // one statement
   ASSERT_EQ(config_.statements_.size(), 1);
@@ -210,7 +184,5 @@ TEST_F(NginxConfigParserStringTest, DoubleQuotesSpecialChars) {
 }
 
 TEST_F(NginxConfigParserStringTest, InvalidDoubleQuotes) {
-  bool success = parseString("foo = test\"hello;");
-
-  EXPECT_FALSE(success);
+  EXPECT_FALSE(parseString("foo = test\"hello;"));
 }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -78,3 +78,26 @@ TEST(NginxConfigParserTest, UnexpectedNewline) {
   EXPECT_EQ(config.statements_[0]->tokens_[0], "foo");
   EXPECT_EQ(config.statements_[0]->tokens_[1], "bar");
 }
+
+TEST(NginxConfigParserTest, OneLineTwoStatements) {
+  NginxConfigParser parser;
+  NginxConfig config;
+
+  std::stringstream test_config_stream("foo bar; baz bop;");
+
+  bool success = parser.Parse(&test_config_stream, &config);
+
+  EXPECT_TRUE(success);
+
+  // two statements
+  ASSERT_EQ(config.statements_.size(), 2);
+  // two tokens each
+  ASSERT_EQ(config.statements_[0]->tokens_.size(), 2);
+  ASSERT_EQ(config.statements_[1]->tokens_.size(), 2);
+
+  EXPECT_EQ(config.statements_[0]->tokens_[0], "foo");
+  EXPECT_EQ(config.statements_[0]->tokens_[1], "bar");
+
+  EXPECT_EQ(config.statements_[1]->tokens_[0], "baz");
+  EXPECT_EQ(config.statements_[1]->tokens_[1], "bop");
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -192,3 +192,19 @@ TEST_F(NginxConfigParserStringTest, DoubleQuotes) {
   EXPECT_EQ(config_.statements_[0]->tokens_[2], "\"Hello, World!\"");
 
 }
+
+TEST_F(NginxConfigParserStringTest, DoubleQuotesSpecialChars) {
+  bool success = parseString("foo = \"test \n test; ' } {\";");
+
+  EXPECT_TRUE(success);
+
+  // one statement
+  ASSERT_EQ(config_.statements_.size(), 1);
+  // three tokens
+  ASSERT_EQ(config_.statements_[0]->tokens_.size(), 3);
+
+  EXPECT_EQ(config_.statements_[0]->tokens_[0], "foo");
+  EXPECT_EQ(config_.statements_[0]->tokens_[1], "=");
+  EXPECT_EQ(config_.statements_[0]->tokens_[2], "\"test \n test; ' } {\"");
+
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -176,3 +176,19 @@ TEST_F(NginxConfigParserStringTest, Comments) {
   EXPECT_EQ(config_.statements_[1]->tokens_[0], "bar");
 
 }
+
+TEST_F(NginxConfigParserStringTest, DoubleQuotes) {
+  bool success = parseString("foo = \"Hello, World!\";");
+
+  EXPECT_TRUE(success);
+
+  // one statement
+  ASSERT_EQ(config_.statements_.size(), 1);
+  // three tokens
+  ASSERT_EQ(config_.statements_[0]->tokens_.size(), 3);
+
+  EXPECT_EQ(config_.statements_[0]->tokens_[0], "foo");
+  EXPECT_EQ(config_.statements_[0]->tokens_[1], "=");
+  EXPECT_EQ(config_.statements_[0]->tokens_[2], "\"Hello, World!\"");
+
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -108,6 +108,31 @@ TEST_F(NginxConfigParserStringTest, ChildStatement) {
   EXPECT_EQ(config_.statements_[0]->child_block_->statements_[0]->tokens_[1], "baz");
 }
 
+TEST_F(NginxConfigParserStringTest, NestedChildStatement) {
+  bool success = parseString(
+          "foo {\
+            bar {\
+              hello;\
+            }\
+            baz;\
+          }");
+
+  EXPECT_TRUE(success);
+
+  NginxConfigStatement* fooStatement = &*config_.statements_[0];
+
+  NginxConfigStatement* barStatement = &*fooStatement->child_block_->statements_[0];
+  NginxConfigStatement* bazStatement = &*fooStatement->child_block_->statements_[1];
+
+  NginxConfigStatement* helloStatement = &*barStatement->child_block_->statements_[0];
+
+
+  EXPECT_EQ(fooStatement->tokens_[0], "foo");
+  EXPECT_EQ(barStatement->tokens_[0], "bar");
+  EXPECT_EQ(bazStatement->tokens_[0], "baz");
+  EXPECT_EQ(helloStatement->tokens_[0], "hello");
+}
+
 TEST_F(NginxConfigParserStringTest, InvalidChildStatement_NoOpenBrace) {
   bool success = parseString("foo } bar;");
 

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -107,3 +107,15 @@ TEST_F(NginxConfigParserStringTest, ChildStatement) {
   EXPECT_EQ(config_.statements_[0]->child_block_->statements_[0]->tokens_[0], "bar");
   EXPECT_EQ(config_.statements_[0]->child_block_->statements_[0]->tokens_[1], "baz");
 }
+
+TEST_F(NginxConfigParserStringTest, InvalidChildStatement_NoOpenBrace) {
+  bool success = parseString("foo } bar;");
+
+  EXPECT_FALSE(success);
+}
+
+TEST_F(NginxConfigParserStringTest, InvalidChildStatement_NoCloseBrace) {
+  bool success = parseString("foo { bar;");
+
+  EXPECT_FALSE(success);
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "config_parser.h"
+#include <sstream>
 
 TEST(NginxConfigParserTest, SimpleConfig) {
   NginxConfigParser parser;
@@ -8,4 +9,23 @@ TEST(NginxConfigParserTest, SimpleConfig) {
   bool success = parser.Parse("example_config", &out_config);
 
   EXPECT_TRUE(success);
+}
+
+TEST(NginxConfigParserTest, StatementParsed) {
+  NginxConfigParser parser;
+  NginxConfig config;
+
+  std::stringstream test_config_stream("port 8080;");
+
+  bool success = parser.Parse(&test_config_stream, &config);
+
+  EXPECT_TRUE(success);
+
+  // one statement
+  ASSERT_EQ(config.statements_.size(), 1);
+  // two tokens
+  ASSERT_EQ(config.statements_[0]->tokens_.size(), 2);
+
+  EXPECT_EQ(config.statements_[0]->tokens_[0], "port");
+  EXPECT_EQ(config.statements_[0]->tokens_[1], "8080");
 }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -11,93 +11,80 @@ TEST(NginxConfigParserTest, SimpleConfig) {
   EXPECT_TRUE(success);
 }
 
-TEST(NginxConfigParserTest, StatementParsed) {
-  NginxConfigParser parser;
-  NginxConfig config;
+class NginxConfigParserStringTest : public ::testing::Test {
+    protected:
+        virtual bool parseString(std::string s) {
+            std::stringstream test_config_stream(s);
 
-  std::stringstream test_config_stream("port 8080;");
+            return parser_.Parse(&test_config_stream, &config_);
+        }
 
-  bool success = parser.Parse(&test_config_stream, &config);
+        NginxConfigParser parser_;
+        NginxConfig config_;
+};
 
-  EXPECT_TRUE(success);
-
-  // one statement
-  ASSERT_EQ(config.statements_.size(), 1);
-  // two tokens
-  ASSERT_EQ(config.statements_[0]->tokens_.size(), 2);
-
-  EXPECT_EQ(config.statements_[0]->tokens_[0], "port");
-  EXPECT_EQ(config.statements_[0]->tokens_[1], "8080");
-}
-
-TEST(NginxConfigParserTest, InsignificantWhitespace) {
-  NginxConfigParser parser;
-  NginxConfig config;
-
-  std::stringstream test_config_stream(" \t   foo  \t   bar     ;    \t");
-
-  bool success = parser.Parse(&test_config_stream, &config);
+TEST_F(NginxConfigParserStringTest, StatementParsed) {
+  bool success = parseString("port 8080;");
 
   EXPECT_TRUE(success);
 
   // one statement
-  ASSERT_EQ(config.statements_.size(), 1);
+  ASSERT_EQ(config_.statements_.size(), 1);
   // two tokens
-  ASSERT_EQ(config.statements_[0]->tokens_.size(), 2);
+  ASSERT_EQ(config_.statements_[0]->tokens_.size(), 2);
 
-  EXPECT_EQ(config.statements_[0]->tokens_[0], "foo");
-  EXPECT_EQ(config.statements_[0]->tokens_[1], "bar");
+  EXPECT_EQ(config_.statements_[0]->tokens_[0], "port");
+  EXPECT_EQ(config_.statements_[0]->tokens_[1], "8080");
 }
 
-TEST(NginxConfigParserTest, NoSemicolon) {
-  NginxConfigParser parser;
-  NginxConfig config;
+TEST_F(NginxConfigParserStringTest, InsignificantWhitespace) {
+  bool success = parseString(" \t   foo  \t   bar     ;    \t");
 
-  std::stringstream test_config_stream("foo bar");
+  EXPECT_TRUE(success);
 
-  bool success = parser.Parse(&test_config_stream, &config);
+  // one statement
+  ASSERT_EQ(config_.statements_.size(), 1);
+  // two tokens
+  ASSERT_EQ(config_.statements_[0]->tokens_.size(), 2);
+
+  EXPECT_EQ(config_.statements_[0]->tokens_[0], "foo");
+  EXPECT_EQ(config_.statements_[0]->tokens_[1], "bar");
+}
+
+TEST_F(NginxConfigParserStringTest, NoSemicolon) {
+  bool success = parseString("foo bar");
 
   EXPECT_FALSE(success);
 }
 
-TEST(NginxConfigParserTest, UnexpectedNewline) {
-  NginxConfigParser parser;
-  NginxConfig config;
-
-  std::stringstream test_config_stream("\nfoo bar;");
-
-  bool success = parser.Parse(&test_config_stream, &config);
+TEST_F(NginxConfigParserStringTest, UnexpectedNewline) {
+  bool success = parseString("\nfoo bar;");
 
   EXPECT_TRUE(success);
 
   // one statement
-  ASSERT_EQ(config.statements_.size(), 1);
+  ASSERT_EQ(config_.statements_.size(), 1);
   // two tokens
-  ASSERT_EQ(config.statements_[0]->tokens_.size(), 2);
+  ASSERT_EQ(config_.statements_[0]->tokens_.size(), 2);
 
-  EXPECT_EQ(config.statements_[0]->tokens_[0], "foo");
-  EXPECT_EQ(config.statements_[0]->tokens_[1], "bar");
+  EXPECT_EQ(config_.statements_[0]->tokens_[0], "foo");
+  EXPECT_EQ(config_.statements_[0]->tokens_[1], "bar");
 }
 
-TEST(NginxConfigParserTest, OneLineTwoStatements) {
-  NginxConfigParser parser;
-  NginxConfig config;
-
-  std::stringstream test_config_stream("foo bar; baz bop;");
-
-  bool success = parser.Parse(&test_config_stream, &config);
+TEST_F(NginxConfigParserStringTest, OneLineTwoStatements) {
+  bool success = parseString("foo bar; baz bop;");
 
   EXPECT_TRUE(success);
 
   // two statements
-  ASSERT_EQ(config.statements_.size(), 2);
+  ASSERT_EQ(config_.statements_.size(), 2);
   // two tokens each
-  ASSERT_EQ(config.statements_[0]->tokens_.size(), 2);
-  ASSERT_EQ(config.statements_[1]->tokens_.size(), 2);
+  ASSERT_EQ(config_.statements_[0]->tokens_.size(), 2);
+  ASSERT_EQ(config_.statements_[1]->tokens_.size(), 2);
 
-  EXPECT_EQ(config.statements_[0]->tokens_[0], "foo");
-  EXPECT_EQ(config.statements_[0]->tokens_[1], "bar");
+  EXPECT_EQ(config_.statements_[0]->tokens_[0], "foo");
+  EXPECT_EQ(config_.statements_[0]->tokens_[1], "bar");
 
-  EXPECT_EQ(config.statements_[1]->tokens_[0], "baz");
-  EXPECT_EQ(config.statements_[1]->tokens_[1], "bop");
+  EXPECT_EQ(config_.statements_[1]->tokens_[0], "baz");
+  EXPECT_EQ(config_.statements_[1]->tokens_[1], "bop");
 }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -144,3 +144,35 @@ TEST_F(NginxConfigParserStringTest, InvalidChildStatement_NoCloseBrace) {
 
   EXPECT_FALSE(success);
 }
+
+TEST_F(NginxConfigParserStringTest, ExtraNewline) {
+  bool success = parseString("foo;\n\n\nbar;");
+
+  EXPECT_TRUE(success);
+
+  // two statements
+  ASSERT_EQ(config_.statements_.size(), 2);
+  // one tokens each
+  ASSERT_EQ(config_.statements_[0]->tokens_.size(), 1);
+  ASSERT_EQ(config_.statements_[1]->tokens_.size(), 1);
+
+  EXPECT_EQ(config_.statements_[0]->tokens_[0], "foo");
+  EXPECT_EQ(config_.statements_[1]->tokens_[0], "bar");
+
+}
+
+TEST_F(NginxConfigParserStringTest, Comments) {
+  bool success = parseString("foo; # this is a comment ;; } {\nbar;");
+
+  EXPECT_TRUE(success);
+
+  // two statements
+  ASSERT_EQ(config_.statements_.size(), 2);
+  // one tokens each
+  ASSERT_EQ(config_.statements_[0]->tokens_.size(), 1);
+  ASSERT_EQ(config_.statements_[1]->tokens_.size(), 1);
+
+  EXPECT_EQ(config_.statements_[0]->tokens_[0], "foo");
+  EXPECT_EQ(config_.statements_[1]->tokens_[0], "bar");
+
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -208,3 +208,9 @@ TEST_F(NginxConfigParserStringTest, DoubleQuotesSpecialChars) {
   EXPECT_EQ(config_.statements_[0]->tokens_[2], "\"test \n test; ' } {\"");
 
 }
+
+TEST_F(NginxConfigParserStringTest, InvalidDoubleQuotes) {
+  bool success = parseString("foo = test\"hello;");
+
+  EXPECT_FALSE(success);
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -48,3 +48,33 @@ TEST(NginxConfigParserTest, InsignificantWhitespace) {
   EXPECT_EQ(config.statements_[0]->tokens_[0], "foo");
   EXPECT_EQ(config.statements_[0]->tokens_[1], "bar");
 }
+
+TEST(NginxConfigParserTest, NoSemicolon) {
+  NginxConfigParser parser;
+  NginxConfig config;
+
+  std::stringstream test_config_stream("foo bar");
+
+  bool success = parser.Parse(&test_config_stream, &config);
+
+  EXPECT_FALSE(success);
+}
+
+TEST(NginxConfigParserTest, UnexpectedNewline) {
+  NginxConfigParser parser;
+  NginxConfig config;
+
+  std::stringstream test_config_stream("\nfoo bar;");
+
+  bool success = parser.Parse(&test_config_stream, &config);
+
+  EXPECT_TRUE(success);
+
+  // one statement
+  ASSERT_EQ(config.statements_.size(), 1);
+  // two tokens
+  ASSERT_EQ(config.statements_[0]->tokens_.size(), 2);
+
+  EXPECT_EQ(config.statements_[0]->tokens_[0], "foo");
+  EXPECT_EQ(config.statements_[0]->tokens_[1], "bar");
+}


### PR DESCRIPTION
Fix unmatched brackets and unmatched quotes unexpectedly parsing without error, and add unit tests for these are other bugs.